### PR TITLE
Bump to 3.34

### DIFF
--- a/org.gnome.Mahjongg.yaml
+++ b/org.gnome.Mahjongg.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --device=dri
+  - --metadata=X-DConf=migrate-path=/org/gnome/Mahjongg/
 
 modules:
   - name: gnome-mahjongg
@@ -16,7 +17,9 @@ modules:
     sources:
         - type: git
           url: https://gitlab.gnome.org/GNOME/gnome-mahjongg.git
-          tag: '3.33.90'
-          commit: '21a13625e2f8f24cc8c4fa6dde10cebad0786b71'
+          tag: '3.32.0'
+          commit: 'ab72d2b3f50f4d96e092c3afcb93c3e7d76bd3b5'
+        - type: patch
+          path: appdata.patch
 cleanup:
   - "/share/man"

--- a/org.gnome.Mahjongg.yaml
+++ b/org.gnome.Mahjongg.yaml
@@ -1,7 +1,7 @@
 app-id: org.gnome.Mahjongg
 runtime: org.gnome.Platform
 sdk: org.gnome.Sdk
-runtime-version: '3.32'
+runtime-version: '3.34'
 command: gnome-mahjongg
 
 finish-args:
@@ -9,10 +9,6 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --device=dri
-  - --filesystem=xdg-run/dconf
-  - --filesystem=~/.config/dconf:ro
-  - --talk-name=ca.desrt.dconf
-  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
 
 modules:
   - name: gnome-mahjongg
@@ -20,9 +16,7 @@ modules:
     sources:
         - type: git
           url: https://gitlab.gnome.org/GNOME/gnome-mahjongg.git
-          tag: '3.32.0'
-          commit: 'ab72d2b3f50f4d96e092c3afcb93c3e7d76bd3b5'
-        - type: patch
-          path: appdata.patch
+          tag: '3.33.90'
+          commit: '21a13625e2f8f24cc8c4fa6dde10cebad0786b71'
 cleanup:
   - "/share/man"


### PR DESCRIPTION
This also removes dconf access which is not needed anymore

DO NOT MERGE:
This doesn't use the latest stable release as it's not released yet. Issue submitted upstream